### PR TITLE
fix wrong data size when bpp=16 condition

### DIFF
--- a/FBpyGIF/fb.py
+++ b/FBpyGIF/fb.py
@@ -340,7 +340,7 @@ def _ready_gif(cut):
     dur = cut.info['duration']/1000
   cut = cut.convert('RGBA' if bpp == 32 else 'RGB').resize((vw,vh), ANTIALIAS)
   if not RGB:
-    return cut.tobytes('raw', 'BGRA' if bpp == 32 else 'BGR'), dur
+    return cut, dur
   return cut.tobytes(), dur
     
 def ready_gif(gif, preview=False):

--- a/FBpyGIF/fb.py
+++ b/FBpyGIF/fb.py
@@ -153,11 +153,9 @@ def report_fb(i=0, layer=0):
   with open('/dev/fb'+str(i), 'r+b')as f:
     vi = ioctl(f, FBIOGET_VSCREENINFO, bytes(160))
     vi = list(struct.unpack('I'*40, vi))
-    print(vi)
     ffm = 'c'*16+'L'+'I'*4+'H'*3+'ILIIHHH'
     fic = struct.calcsize(ffm)
     fi = struct.unpack(ffm, ioctl(f, FBIOGET_FSCREENINFO, bytes(fic)))
-    print(fi)
 
 def ready_fb(_bpp=None, i=0, layer=0, _win=None):
   global mm, bpp, w, h, vi, fi, RGB, msize_kb, vx, vy, vw, vh, bytepp


### PR DESCRIPTION
My Raspberry Pi's TFT screen's bpp(bits per pixel) is 16,
the line cut.tobytes('raw', 'BGRA' if bpp == 32 else 'BGR') in _ready_gif() returns a bytes data with 24 bits per pixel,
and then show_img() writes the img directly into framebuffer wrongly.
My solution is a workaround which not calling tobytes() function in _ready_gif() function, but passing the image obj directly into show_img()
